### PR TITLE
Added return types to getIterator() and count() for compatibility with PHP 8.1

### DIFF
--- a/src/CSS/Selector.php
+++ b/src/CSS/Selector.php
@@ -61,7 +61,7 @@ class Selector implements EventHandler, \IteratorAggregate, \Countable
         $this->selectors[$this->groupIndex][] = $this->currSelector;
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->selectors);
     }
@@ -78,7 +78,7 @@ class Selector implements EventHandler, \IteratorAggregate, \Countable
         return $this->selectors;
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->selectors);
     }

--- a/src/DOMQuery.php
+++ b/src/DOMQuery.php
@@ -1528,7 +1528,7 @@ class DOMQuery extends DOM
      * @return Iterable
      *  Returns an iterator.
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         $i = new QueryPathIterator($this->matches);
         $i->options = $this->options;


### PR DESCRIPTION
In PHP 8.1, the methods `getIterator()` and `count()` need to have return types.

Currently, this causes tests to fail in the Drupal module "Feeds Extensible Parsers":
https://www.drupal.org/pift-ci-job/2347356

I did see that there exist an alternative querypath library called "satisfactory-clips-archive/querypath", but the issue with that one is that it _requires_ PHP 8.1 and my project needs to support PHP 7.3 as well.
https://github.com/Satisfactory-Clips-Archive/querypath