### PR TITLE
PHP8.1 deprecation notice: trim only accepts string type.

### DIFF
--- a/src/DOM.php
+++ b/src/DOM.php
@@ -66,7 +66,7 @@ abstract class DOM implements Query, \IteratorAggregate, \Countable
      * @see qp()
      * @throws Exception
      */
-    public function __construct($document = NULL, $string = NULL, $options = [])
+    public function __construct($document = NULL, $string = '', $options = [])
     {
         $string = trim($string);
         $this->options = $options + Options::get() + $this->options;


### PR DESCRIPTION
Fixes #13 